### PR TITLE
changes

### DIFF
--- a/api/src/graphql/resolvers/gp/query.ts
+++ b/api/src/graphql/resolvers/gp/query.ts
@@ -1,4 +1,3 @@
-// src/graphql/resolvers/gp/query.ts
 import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
@@ -24,36 +23,92 @@ export const gpQueries = {
 
     return {
       ...gp,
-      id_api_races: gp.id_api_races.toString(), // conversion ID
+      id_api_races: gp.id_api_races.toString(),
       date: new Date(gp.date).toISOString().split('T')[0],
       track: {
         ...gp.track,
-        id_api_tracks: gp.track.id_api_tracks.toString(), // aussi ici
+        id_api_tracks: gp.track.id_api_tracks.toString(),
       },
     };
   },
+
   getUpcomingGPs: async () => {
-  const now = new Date();
+    const now = new Date();
 
-  const gps = await prisma.gP.findMany({
-    where: {
-      date: {
-        gt: now,
+    const gps = await prisma.gP.findMany({
+      where: {
+        date: {
+          gt: now,
+        },
       },
-    },
-    orderBy: {
-      date: 'asc',
-    },
-    include: {
-      track: true,
-    },
-  });
+      orderBy: {
+        date: 'asc',
+      },
+      include: {
+        track: true,
+      },
+    });
 
-  return gps.map((gp) => ({
-    ...gp,
-    id_api_races: gp.id_api_races.toString(),
-    date: gp.date.getTime().toString(), // ← pour éviter le même bug avec date
-    time: gp.time?.toISOString() || '', // ← si jamais
-  }));
-}
+    return gps.map((gp) => ({
+      ...gp,
+      id_api_races: gp.id_api_races.toString(),
+      date: gp.date.toISOString().split('T')[0],
+      time: gp.time?.toISOString() || '',
+      track: {
+        ...gp.track,
+        id_api_tracks: gp.track.id_api_tracks.toString(),
+      },
+    }));
+  },
+
+  getPastGPs: async () => {
+    const now = new Date();
+
+    const gps = await prisma.gP.findMany({
+      where: {
+        date: {
+          lt: now,
+        },
+      },
+      orderBy: {
+        date: 'desc',
+      },
+      include: {
+        track: true,
+      },
+    });
+
+    return gps.map((gp) => ({
+      ...gp,
+      id_api_races: gp.id_api_races.toString(),
+      date: gp.date.toISOString().split('T')[0],
+      time: gp.time?.toISOString() || '',
+      track: {
+        ...gp.track,
+        id_api_tracks: gp.track.id_api_tracks.toString(),
+      },
+    }));
+  },
+
+  getAllGPs: async () => {
+    const gps = await prisma.gP.findMany({
+      orderBy: {
+        date: 'asc',
+      },
+      include: {
+        track: true,
+      },
+    });
+
+    return gps.map((gp) => ({
+      ...gp,
+      id_api_races: gp.id_api_races.toString(),
+      date: gp.date.toISOString().split('T')[0],
+      time: gp.time?.toISOString() || '',
+      track: {
+        ...gp.track,
+        id_api_tracks: gp.track.id_api_tracks.toString(),
+      },
+    }));
+  },
 };

--- a/api/src/graphql/schemas/schema.ts
+++ b/api/src/graphql/schemas/schema.ts
@@ -57,7 +57,7 @@ export const typeDefs = gql`
   }
 
   type Track {
-    id_api_tracks: Int!
+    id_api_tracks: String!
     country_name: String!
     track_name: String!
     picture_country: String
@@ -137,6 +137,8 @@ export const typeDefs = gql`
     user(id: ID!): User
     getNextGP: GP
     getUpcomingGPs: [GP!]!
+    getPastGPs: [GP!]!
+    getAllGPs: [GP!]!
     league(id: ID!): League
       getPublicLeagues: [League!]!
 


### PR DESCRIPTION
This pull request introduces several updates to the GraphQL API, focusing on improving the handling of Grand Prix (GP) data. Key changes include adding new query resolvers for retrieving past and all GPs, standardizing date formatting, and updating the schema to reflect these changes.

### Enhancements to GP Query Resolvers:
* Added new resolvers `getPastGPs` and `getAllGPs` to fetch past and all GPs, respectively, with appropriate filtering, ordering, and inclusion of related track data. (`api/src/graphql/resolvers/gp/query.ts`, [api/src/graphql/resolvers/gp/query.tsL55-R113](diffhunk://#diff-8ed062887fac3bc8251e4194edcd7c22f9cc64d5cd0cb5217711c77485cb505eL55-R113))
* Updated existing resolvers to format GP dates as `YYYY-MM-DD` using `toISOString().split('T')[0]` for consistency. (`api/src/graphql/resolvers/gp/query.ts`, [[1]](diffhunk://#diff-8ed062887fac3bc8251e4194edcd7c22f9cc64d5cd0cb5217711c77485cb505eL27-R34) [[2]](diffhunk://#diff-8ed062887fac3bc8251e4194edcd7c22f9cc64d5cd0cb5217711c77485cb505eL55-R113)

### Schema Updates:
* Changed `id_api_tracks` in the `Track` type from `Int!` to `String!` to align with the updated data handling. (`api/src/graphql/schemas/schema.ts`, [api/src/graphql/schemas/schema.tsL60-R60](diffhunk://#diff-f762d2d19aadc3fb982cd834ea3cebf351b2332c0395fc861ad9b5ad6939f2f1L60-R60))
* Added `getPastGPs` and `getAllGPs` queries to the GraphQL schema to expose the new functionality. (`api/src/graphql/schemas/schema.ts`, [api/src/graphql/schemas/schema.tsR140-R141](diffhunk://#diff-f762d2d19aadc3fb982cd834ea3cebf351b2332c0395fc861ad9b5ad6939f2f1R140-R141))